### PR TITLE
feat: make msg type generic

### DIFF
--- a/src/event/entry.rs
+++ b/src/event/entry.rs
@@ -1,11 +1,9 @@
 use std::hash::Hash;
 
-use crate::publisher::Id;
+use super::{origin::Origin, Id, Msg};
 
-use super::origin::Origin;
-
-pub trait EventEntry<K: Id>: Default + Clone + Hash + Send + Sync + 'static {
-    fn new(event_id: K, msg: &str, origin: Origin) -> Self;
+pub trait EventEntry<K: Id, M: Msg>: Default + Clone + Hash + Send + Sync + 'static {
+    fn new(event_id: K, msg: Option<impl Into<M>>, origin: Origin) -> Self;
 
     fn get_event_id(&self) -> &K;
 
@@ -14,7 +12,7 @@ pub trait EventEntry<K: Id>: Default + Clone + Hash + Send + Sync + 'static {
     fn get_entry_id(&self) -> crate::uuid::Uuid;
 
     /// Get the main message that was set when the event entry was created.
-    fn get_msg(&self) -> &str;
+    fn get_msg(&self) -> Option<&M>;
 
     fn get_origin(&self) -> &Origin;
 }

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -1,30 +1,34 @@
 use std::marker::PhantomData;
 
-use crate::publisher::{CaptureControl, Id};
+use crate::publisher::CaptureControl;
 
-use super::entry::EventEntry;
+use super::{entry::EventEntry, Id, Msg};
 
-pub trait Filter<K>
+pub trait Filter<K, M>
 where
     K: Id + CaptureControl,
+    M: Msg,
 {
     /// Return `true` if the entry is allowed to be captured.
-    fn allow_entry(&self, entry: &impl EventEntry<K>) -> bool;
+    fn allow_entry(&self, entry: &impl EventEntry<K, M>) -> bool;
 }
 
 #[derive(Default, Debug)]
-pub struct DummyFilter<K>
+pub struct DummyFilter<K, M>
 where
     K: Id + CaptureControl,
+    M: Msg,
 {
-    v: PhantomData<K>,
+    v1: PhantomData<K>,
+    v2: PhantomData<M>,
 }
 
-impl<K> Filter<K> for DummyFilter<K>
+impl<K, M> Filter<K, M> for DummyFilter<K, M>
 where
     K: Id + CaptureControl,
+    M: Msg,
 {
-    fn allow_entry(&self, _entry: &impl EventEntry<K>) -> bool {
+    fn allow_entry(&self, _entry: &impl EventEntry<K, M>) -> bool {
         true
     }
 }

--- a/src/event/finalized.rs
+++ b/src/event/finalized.rs
@@ -1,4 +1,4 @@
-use crate::publisher::Id;
+use super::Id;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct FinalizedEvent<K: Id> {

--- a/src/event/intermediary.rs
+++ b/src/event/intermediary.rs
@@ -1,14 +1,13 @@
-use crate::publisher::Id;
+use super::{entry::EventEntry, finalized::FinalizedEvent, origin::Origin, Id, Msg};
 
-use super::{entry::EventEntry, finalized::FinalizedEvent, origin::Origin};
-
-pub trait IntermediaryEvent<K, T>
+pub trait IntermediaryEvent<K, M, T>
 where
     Self: std::marker::Sized,
     K: Id,
-    T: EventEntry<K>,
+    M: Msg,
+    T: EventEntry<K, M>,
 {
-    fn new(event_id: K, msg: &str, origin: Origin) -> Self;
+    fn new(event_id: K, msg: Option<impl Into<M>>, origin: Origin) -> Self;
 
     fn get_entry(&self) -> &T;
 

--- a/tests/min_concretise/entry.rs
+++ b/tests/min_concretise/entry.rs
@@ -5,18 +5,16 @@ use super::id::MinId;
 #[derive(Default, Clone)]
 pub struct MinEventEntry {
     event_id: MinId,
-    msg: String,
-
+    msg: Option<String>,
     entry_id: evident::uuid::Uuid,
     origin: Origin,
 }
 
-impl EventEntry<MinId> for MinEventEntry {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl EventEntry<MinId, String> for MinEventEntry {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinEventEntry {
             event_id,
-            msg: msg.to_string(),
-
+            msg: msg.map(|m| m.into()),
             entry_id: evident::uuid::Uuid::new_v4(),
             origin,
         }
@@ -34,8 +32,8 @@ impl EventEntry<MinId> for MinEventEntry {
         self.entry_id
     }
 
-    fn get_msg(&self) -> &str {
-        &self.msg
+    fn get_msg(&self) -> Option<&String> {
+        self.msg.as_ref()
     }
 
     fn get_origin(&self) -> &evident::event::origin::Origin {

--- a/tests/min_concretise/id.rs
+++ b/tests/min_concretise/id.rs
@@ -3,7 +3,7 @@ pub struct MinId {
     pub id: isize,
 }
 
-impl evident::publisher::Id for MinId {}
+impl evident::event::Id for MinId {}
 
 const START_CAPTURING: MinId = MinId { id: -1 };
 const STOP_CAPTURING: MinId = MinId { id: -2 };

--- a/tests/min_concretise/interim_event.rs
+++ b/tests/min_concretise/interim_event.rs
@@ -6,8 +6,8 @@ pub struct MinInterimEvent {
     entry: MinEventEntry,
 }
 
-impl IntermediaryEvent<MinId, MinEventEntry> for MinInterimEvent {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl IntermediaryEvent<MinId, String, MinEventEntry> for MinInterimEvent {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinInterimEvent {
             entry: MinEventEntry::new(event_id, msg, origin),
         }

--- a/tests/min_concretise/mod.rs
+++ b/tests/min_concretise/mod.rs
@@ -9,6 +9,7 @@ mod interim_event;
 evident::create_static_publisher!(
     PUBLISHER,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent,
     capture_channel_bound = 1,
@@ -21,6 +22,7 @@ evident::create_static_publisher!(
 evident::create_set_event_macro!(
     no_export,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent
 );

--- a/tests/min_filter/entry.rs
+++ b/tests/min_filter/entry.rs
@@ -5,18 +5,16 @@ use super::id::MinId;
 #[derive(Default, Clone)]
 pub struct MinEventEntry {
     event_id: MinId,
-    msg: String,
-
+    msg: Option<String>,
     entry_id: evident::uuid::Uuid,
     origin: Origin,
 }
 
-impl EventEntry<MinId> for MinEventEntry {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl EventEntry<MinId, String> for MinEventEntry {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinEventEntry {
             event_id,
-            msg: msg.to_string(),
-
+            msg: msg.map(|m| m.into()),
             entry_id: evident::uuid::Uuid::new_v4(),
             origin,
         }
@@ -34,8 +32,8 @@ impl EventEntry<MinId> for MinEventEntry {
         self.entry_id
     }
 
-    fn get_msg(&self) -> &str {
-        &self.msg
+    fn get_msg(&self) -> Option<&String> {
+        self.msg.as_ref()
     }
 
     fn get_origin(&self) -> &evident::event::origin::Origin {

--- a/tests/min_filter/filter.rs
+++ b/tests/min_filter/filter.rs
@@ -5,8 +5,8 @@ use super::id::MinId;
 #[derive(Default)]
 pub struct MinFilter {}
 
-impl Filter<MinId> for MinFilter {
-    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<MinId>) -> bool {
+impl Filter<MinId, String> for MinFilter {
+    fn allow_entry(&self, entry: &impl evident::event::entry::EventEntry<MinId, String>) -> bool {
         if entry.get_event_id().id % 2 == 0 {
             return true;
         }

--- a/tests/min_filter/id.rs
+++ b/tests/min_filter/id.rs
@@ -3,7 +3,7 @@ pub struct MinId {
     pub id: isize,
 }
 
-impl evident::publisher::Id for MinId {}
+impl evident::event::Id for MinId {}
 
 // Note: `id: 1` is important, since filter would not allow an event with this id.
 // Test in `mod` ensures that stop capturing event is still captured.

--- a/tests/min_filter/interim_event.rs
+++ b/tests/min_filter/interim_event.rs
@@ -6,8 +6,8 @@ pub struct MinInterimEvent {
     entry: MinEventEntry,
 }
 
-impl IntermediaryEvent<MinId, MinEventEntry> for MinInterimEvent {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl IntermediaryEvent<MinId, String, MinEventEntry> for MinInterimEvent {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinInterimEvent {
             entry: MinEventEntry::new(event_id, msg, origin),
         }

--- a/tests/min_filter/mod.rs
+++ b/tests/min_filter/mod.rs
@@ -12,6 +12,7 @@ mod interim_event;
 evident::create_static_publisher!(
     PUBLISHER,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent,
     filter_type = MinFilter,
@@ -26,6 +27,7 @@ evident::create_static_publisher!(
 evident::create_set_event_macro!(
     no_export,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent
 );

--- a/tests/min_msg/entry.rs
+++ b/tests/min_msg/entry.rs
@@ -1,0 +1,42 @@
+use evident::event::{entry::EventEntry, origin::Origin};
+
+use super::{id::MinId, msg::MinMsg};
+
+#[derive(Default, Clone)]
+pub struct MinEventEntry {
+    event_id: MinId,
+    msg: Option<MinMsg>,
+    entry_id: evident::uuid::Uuid,
+    origin: Origin,
+}
+
+impl EventEntry<MinId, MinMsg> for MinEventEntry {
+    fn new(event_id: MinId, msg: Option<impl Into<MinMsg>>, origin: Origin) -> Self {
+        MinEventEntry {
+            event_id,
+            msg: msg.map(|m| m.into()),
+            entry_id: evident::uuid::Uuid::new_v4(),
+            origin,
+        }
+    }
+
+    fn get_event_id(&self) -> &MinId {
+        &self.event_id
+    }
+
+    fn into_event_id(self) -> MinId {
+        self.event_id
+    }
+
+    fn get_entry_id(&self) -> evident::uuid::Uuid {
+        self.entry_id
+    }
+
+    fn get_msg(&self) -> Option<&MinMsg> {
+        self.msg.as_ref()
+    }
+
+    fn get_origin(&self) -> &evident::event::origin::Origin {
+        &self.origin
+    }
+}

--- a/tests/min_msg/id.rs
+++ b/tests/min_msg/id.rs
@@ -1,0 +1,27 @@
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq, Copy)]
+pub struct MinId {
+    pub id: isize,
+}
+
+impl evident::event::Id for MinId {}
+
+const START_CAPTURING: MinId = MinId { id: -1 };
+const STOP_CAPTURING: MinId = MinId { id: -2 };
+
+impl evident::publisher::CaptureControl for MinId {
+    fn start(id: &Self) -> bool {
+        id == &START_CAPTURING
+    }
+
+    fn start_id() -> Self {
+        START_CAPTURING
+    }
+
+    fn stop(id: &Self) -> bool {
+        id == &STOP_CAPTURING
+    }
+
+    fn stop_id() -> Self {
+        STOP_CAPTURING
+    }
+}

--- a/tests/min_msg/interim_event.rs
+++ b/tests/min_msg/interim_event.rs
@@ -1,0 +1,23 @@
+use evident::event::{entry::EventEntry, intermediary::IntermediaryEvent, origin::Origin};
+
+use super::{entry::MinEventEntry, id::MinId, msg::MinMsg};
+
+pub struct MinInterimEvent {
+    entry: MinEventEntry,
+}
+
+impl IntermediaryEvent<MinId, MinMsg, MinEventEntry> for MinInterimEvent {
+    fn new(event_id: MinId, msg: Option<impl Into<MinMsg>>, origin: Origin) -> Self {
+        MinInterimEvent {
+            entry: MinEventEntry::new(event_id, msg, origin),
+        }
+    }
+
+    fn get_entry(&self) -> &MinEventEntry {
+        &self.entry
+    }
+
+    fn take_entry(&mut self) -> MinEventEntry {
+        std::mem::take(&mut self.entry)
+    }
+}

--- a/tests/min_msg/mod.rs
+++ b/tests/min_msg/mod.rs
@@ -1,0 +1,56 @@
+use evident::publisher::{CaptureMode, EventTimestampKind};
+
+use self::{entry::MinEventEntry, id::MinId, interim_event::MinInterimEvent, msg::MinMsg};
+
+mod entry;
+mod id;
+mod interim_event;
+mod msg;
+
+evident::create_static_publisher!(
+    PUBLISHER,
+    id_type = MinId,
+    msg_type = MinMsg,
+    entry_type = MinEventEntry,
+    interm_event_type = MinInterimEvent,
+    capture_channel_bound = 1,
+    subscription_channel_bound = 1,
+    capture_mode = CaptureMode::Blocking,
+    timestamp_kind = EventTimestampKind::Created
+);
+
+// Note: **no_export** to prevent the macro from adding `#[macro_export]`.
+evident::create_set_event_macro!(
+    no_export,
+    id_type = MinId,
+    msg_type = MinMsg,
+    entry_type = MinEventEntry,
+    interm_event_type = MinInterimEvent
+);
+
+#[test]
+fn setup_minimal_msg() {
+    let some_id = MinId { id: 3 };
+    let msg = MinMsg { nr: 1 };
+
+    let sub = PUBLISHER.subscribe(some_id).unwrap();
+
+    set_event!(some_id, msg.clone()).finalize();
+
+    let event = sub
+        .get_receiver()
+        .recv_timeout(std::time::Duration::from_millis(100))
+        .unwrap();
+
+    assert_eq!(
+        event.get_event_id(),
+        &some_id,
+        "Sent and received Ids differ."
+    );
+
+    assert_eq!(
+        event.get_msg().unwrap(),
+        &msg,
+        "Sent and received messages differ."
+    );
+}

--- a/tests/min_msg/msg.rs
+++ b/tests/min_msg/msg.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MinMsg {
+    pub nr: usize,
+}
+
+impl evident::event::Msg for MinMsg {}

--- a/tests/pub_sub/set_events.rs
+++ b/tests/pub_sub/set_events.rs
@@ -108,13 +108,13 @@ fn set_same_event_twice_with_same_origin() {
 
     let recv = TESTS_PUBLISHER.subscribe(id).unwrap();
 
-    evident::event::set_event_with_msg::<MinId, MinEventEntry, MinInterimEvent>(
+    evident::event::set_event_with_msg::<MinId, String, MinEventEntry, MinInterimEvent>(
         id,
         msg,
         Origin::new(module_path!(), file!(), line),
     )
     .finalize();
-    evident::event::set_event_with_msg::<MinId, MinEventEntry, MinInterimEvent>(
+    evident::event::set_event_with_msg::<MinId, String, MinEventEntry, MinInterimEvent>(
         id,
         msg,
         Origin::new(module_path!(), file!(), line),
@@ -163,7 +163,7 @@ fn set_event_received_exactly_once_per_receiver() {
         .unwrap();
 
     assert_eq!(
-        recv_1_event_1.get_msg(),
+        recv_1_event_1.get_msg().unwrap(),
         msg,
         "Event messages are not equal."
     );
@@ -183,7 +183,7 @@ fn set_event_received_exactly_once_per_receiver() {
         .unwrap();
 
     assert_eq!(
-        recv_2_event_1.get_msg(),
+        recv_2_event_1.get_msg().unwrap(),
         msg,
         "Event messages are not equal."
     );
@@ -212,7 +212,7 @@ fn set_event_with_literal_msg() {
         .unwrap();
 
     assert_eq!(
-        event.get_msg(),
+        event.get_msg().unwrap(),
         "Set event message",
         "Event messages are not equal."
     );
@@ -232,7 +232,7 @@ fn set_event_using_msg_expression() {
         .unwrap();
 
     assert_eq!(
-        event.get_msg(),
+        event.get_msg().unwrap(),
         &format!("Set message with id={}", id),
         "Event messages are not equal."
     );
@@ -299,13 +299,11 @@ fn set_event_has_current_thread_id() {
 
 #[test]
 fn spawned_set_event_has_different_thread_id() {
-    let msg = "Set first message";
-
     let recv = TESTS_PUBLISHER.subscribe(TestLogId::Id.into()).unwrap();
     let thread_id = std::thread::current().id();
 
     std::thread::spawn(|| {
-        set_event!(TestLogId::Id.into(), msg).finalize();
+        set_event!(TestLogId::Id.into(), "Set event message").finalize();
     });
 
     std::thread::sleep(std::time::Duration::from_millis(10));

--- a/tests/pub_sub/setup/entry.rs
+++ b/tests/pub_sub/setup/entry.rs
@@ -5,18 +5,16 @@ use super::id::MinId;
 #[derive(Default, Clone)]
 pub struct MinEventEntry {
     event_id: MinId,
-    msg: String,
-
+    msg: Option<String>,
     entry_id: evident::uuid::Uuid,
     origin: Origin,
 }
 
-impl EventEntry<MinId> for MinEventEntry {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl EventEntry<MinId, String> for MinEventEntry {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinEventEntry {
             event_id,
-            msg: msg.to_string(),
-
+            msg: msg.map(|m| m.into()),
             entry_id: evident::uuid::Uuid::new_v4(),
             origin,
         }
@@ -34,8 +32,8 @@ impl EventEntry<MinId> for MinEventEntry {
         self.entry_id
     }
 
-    fn get_msg(&self) -> &str {
-        &self.msg
+    fn get_msg(&self) -> Option<&String> {
+        self.msg.as_ref()
     }
 
     fn get_origin(&self) -> &evident::event::origin::Origin {

--- a/tests/pub_sub/setup/id.rs
+++ b/tests/pub_sub/setup/id.rs
@@ -3,7 +3,7 @@ pub struct MinId {
     pub id: isize,
 }
 
-impl evident::publisher::Id for MinId {}
+impl evident::event::Id for MinId {}
 
 impl std::fmt::Display for MinId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/tests/pub_sub/setup/interim_event.rs
+++ b/tests/pub_sub/setup/interim_event.rs
@@ -6,8 +6,8 @@ pub struct MinInterimEvent {
     entry: MinEventEntry,
 }
 
-impl IntermediaryEvent<MinId, MinEventEntry> for MinInterimEvent {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl IntermediaryEvent<MinId, String, MinEventEntry> for MinInterimEvent {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinInterimEvent {
             entry: MinEventEntry::new(event_id, msg, origin),
         }

--- a/tests/pub_sub/setup/mod.rs
+++ b/tests/pub_sub/setup/mod.rs
@@ -9,6 +9,7 @@ pub mod interim_event;
 evident::create_static_publisher!(
     pub TESTS_PUBLISHER,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent,
     capture_channel_bound = 500,
@@ -20,6 +21,7 @@ evident::create_static_publisher!(
 evident::create_set_event_macro!(
     no_export,
     id_type = crate::pub_sub::setup::id::MinId,
+    msg_type = String,
     entry_type = crate::pub_sub::setup::entry::MinEventEntry,
     interm_event_type = crate::pub_sub::setup::interim_event::MinInterimEvent
 );

--- a/tests/pub_sub/subscription.rs
+++ b/tests/pub_sub/subscription.rs
@@ -22,7 +22,11 @@ fn two_ids_separate_receiver() {
         &id_1,
         "Received event 1 has wrong Id."
     );
-    assert_eq!(event_1.get_msg(), msg_1, "Received event 1 has wrong msg.");
+    assert_eq!(
+        event_1.get_msg().unwrap(),
+        msg_1,
+        "Received event 1 has wrong msg."
+    );
 
     let event_2 = recv_2
         .get_receiver()
@@ -33,7 +37,11 @@ fn two_ids_separate_receiver() {
         &id_2,
         "Received event 2 has wrong Id."
     );
-    assert_eq!(event_2.get_msg(), msg_2, "Received event 2 has wrong msg.");
+    assert_eq!(
+        event_2.get_msg().unwrap(),
+        msg_2,
+        "Received event 2 has wrong msg."
+    );
 }
 
 #[test]
@@ -55,7 +63,11 @@ fn one_id_separate_receiver() {
         &id,
         "Received event 1 has wrong Id."
     );
-    assert_eq!(event_1.get_msg(), msg, "Received event 1 has wrong msg.");
+    assert_eq!(
+        event_1.get_msg().unwrap(),
+        msg,
+        "Received event 1 has wrong msg."
+    );
 
     let event_2 = recv_2
         .get_receiver()
@@ -66,7 +78,11 @@ fn one_id_separate_receiver() {
         &id,
         "Received event 2 has wrong Id."
     );
-    assert_eq!(event_2.get_msg(), msg, "Received event 2 has wrong msg.");
+    assert_eq!(
+        event_2.get_msg().unwrap(),
+        msg,
+        "Received event 2 has wrong msg."
+    );
 
     assert_eq!(event_1, event_2, "Received events are not equal.");
 }
@@ -92,7 +108,7 @@ fn subscribe_to_two_ids_at_once() {
         "Received event 1 has wrong Id."
     );
     assert!(
-        event_1.get_msg() == msg_1 || event_1.get_msg() == msg_2,
+        event_1.get_msg().unwrap() == msg_1 || event_1.get_msg().unwrap() == msg_2,
         "Received event 1 has wrong msg."
     );
 
@@ -105,7 +121,7 @@ fn subscribe_to_two_ids_at_once() {
         "Received event 2 has wrong Id."
     );
     assert!(
-        event_2.get_msg() == msg_1 || event_2.get_msg() == msg_2,
+        event_2.get_msg().unwrap() == msg_1 || event_2.get_msg().unwrap() == msg_2,
         "Received event 2 has wrong msg."
     );
     assert_ne!(
@@ -136,7 +152,11 @@ fn receiver_for_all_events_two_events_set() {
         &id_1,
         "Received event 1 has wrong Id."
     );
-    assert_eq!(event_1.get_msg(), msg_1, "Received event 1 has wrong msg.");
+    assert_eq!(
+        event_1.get_msg().unwrap(),
+        msg_1,
+        "Received event 1 has wrong msg."
+    );
 
     let event_2 = recv_all
         .get_receiver()
@@ -147,7 +167,11 @@ fn receiver_for_all_events_two_events_set() {
         &id_2,
         "Received event 2 has wrong Id."
     );
-    assert_eq!(event_2.get_msg(), msg_2, "Received event 2 has wrong msg.");
+    assert_eq!(
+        event_2.get_msg().unwrap(),
+        msg_2,
+        "Received event 2 has wrong msg."
+    );
 }
 
 #[test]
@@ -169,7 +193,11 @@ fn receiver_unsubscribes_single_id() {
         &id_1,
         "Received event 1 has wrong Id."
     );
-    assert_eq!(event_1.get_msg(), msg_1, "Received event 1 has wrong msg.");
+    assert_eq!(
+        event_1.get_msg().unwrap(),
+        msg_1,
+        "Received event 1 has wrong msg."
+    );
 
     recv.unsubscribe_id(id_1).unwrap();
 
@@ -216,7 +244,11 @@ fn receiver_subscribes_to_new_id() {
         &id_1,
         "Received event 1 has wrong Id."
     );
-    assert_eq!(event_1.get_msg(), msg_1, "Received event 1 has wrong msg.");
+    assert_eq!(
+        event_1.get_msg().unwrap(),
+        msg_1,
+        "Received event 1 has wrong msg."
+    );
 
     // Note: Sleep guarantees that `on_event` thread processed all previous events.
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -235,7 +267,11 @@ fn receiver_subscribes_to_new_id() {
         &id_2,
         "Received event 2 has wrong Id."
     );
-    assert_eq!(event_2.get_msg(), msg_2, "Received event 2 has wrong msg.");
+    assert_eq!(
+        event_2.get_msg().unwrap(),
+        msg_2,
+        "Received event 2 has wrong msg."
+    );
 }
 
 #[test]

--- a/tests/pub_sub/threading.rs
+++ b/tests/pub_sub/threading.rs
@@ -33,7 +33,7 @@ fn set_different_events_in_two_threads() {
         "Received side event has wrong Id."
     );
     assert_eq!(
-        event_side.get_msg(),
+        event_side.get_msg().unwrap(),
         msg_side,
         "Received side event has wrong msg."
     );
@@ -48,7 +48,7 @@ fn set_different_events_in_two_threads() {
         "Received main event has wrong Id."
     );
     assert_eq!(
-        event_main.get_msg(),
+        event_main.get_msg().unwrap(),
         msg_main,
         "Received main event has wrong msg."
     );
@@ -80,7 +80,7 @@ fn set_same_event_in_two_threads() {
         "Received event 1 has wrong Id."
     );
     assert!(
-        event_1.get_msg() == msg_main || event_1.get_msg() == msg_side,
+        event_1.get_msg().unwrap() == msg_main || event_1.get_msg().unwrap() == msg_side,
         "Received event 1 has wrong msg."
     );
 
@@ -94,7 +94,7 @@ fn set_same_event_in_two_threads() {
         "Received event 2 has wrong Id."
     );
     assert!(
-        event_2.get_msg() == msg_main || event_2.get_msg() == msg_side,
+        event_2.get_msg().unwrap() == msg_main || event_2.get_msg().unwrap() == msg_side,
         "Received event 2 has wrong msg."
     );
 

--- a/tests/public_concretise/entry.rs
+++ b/tests/public_concretise/entry.rs
@@ -5,18 +5,16 @@ use super::id::MinId;
 #[derive(Default, Clone)]
 pub struct MinEventEntry {
     event_id: MinId,
-    msg: String,
-
+    msg: Option<String>,
     entry_id: evident::uuid::Uuid,
     origin: Origin,
 }
 
-impl EventEntry<MinId> for MinEventEntry {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl EventEntry<MinId, String> for MinEventEntry {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinEventEntry {
             event_id,
-            msg: msg.to_string(),
-
+            msg: msg.map(|m| m.into()),
             entry_id: evident::uuid::Uuid::new_v4(),
             origin,
         }
@@ -34,8 +32,8 @@ impl EventEntry<MinId> for MinEventEntry {
         self.entry_id
     }
 
-    fn get_msg(&self) -> &str {
-        &self.msg
+    fn get_msg(&self) -> Option<&String> {
+        self.msg.as_ref()
     }
 
     fn get_origin(&self) -> &evident::event::origin::Origin {

--- a/tests/public_concretise/id.rs
+++ b/tests/public_concretise/id.rs
@@ -3,7 +3,7 @@ pub struct MinId {
     pub id: isize,
 }
 
-impl evident::publisher::Id for MinId {}
+impl evident::event::Id for MinId {}
 
 const START_CAPTURING: MinId = MinId { id: -1 };
 const STOP_CAPTURING: MinId = MinId { id: -2 };

--- a/tests/public_concretise/interim_event.rs
+++ b/tests/public_concretise/interim_event.rs
@@ -6,8 +6,8 @@ pub struct MinInterimEvent {
     entry: MinEventEntry,
 }
 
-impl IntermediaryEvent<MinId, MinEventEntry> for MinInterimEvent {
-    fn new(event_id: MinId, msg: &str, origin: Origin) -> Self {
+impl IntermediaryEvent<MinId, String, MinEventEntry> for MinInterimEvent {
+    fn new(event_id: MinId, msg: Option<impl Into<String>>, origin: Origin) -> Self {
         MinInterimEvent {
             entry: MinEventEntry::new(event_id, msg, origin),
         }

--- a/tests/public_concretise/public_publisher.rs
+++ b/tests/public_concretise/public_publisher.rs
@@ -7,6 +7,7 @@ use crate::public_concretise::{entry::MinEventEntry, id::MinId, interim_event::M
 evident::create_static_publisher!(
     pub PUB_PUBLISHER,
     id_type = MinId,
+    msg_type = String,
     entry_type = MinEventEntry,
     interm_event_type = MinInterimEvent,
     capture_channel_bound = 1,
@@ -18,6 +19,7 @@ evident::create_static_publisher!(
 // Note: Fully qualified path to access the generated `set_event!()` macro from anywhere.
 evident::create_set_event_macro!(
     id_type = crate::public_concretise::MinId,
+    msg_type = String,
     entry_type = crate::public_concretise::entry::MinEventEntry,
     interm_event_type = crate::public_concretise::interim_event::MinInterimEvent
 );

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
 pub mod min_concretise;
 pub mod min_filter;
+pub mod min_msg;
 pub mod pub_sub;
 pub mod public_concretise;


### PR DESCRIPTION
This PR makes the msg type of an event generic.
Currently, the msg type is not concrete, but had to be something that can be created from `&str`, and returned as `&str`.

Making the msg type generic increases the implementation effort for new publishers slightly, because the concrete msg type must be set for the concrete types implementing the traits Entry, ImmediaryEvent, and Filter.
However, the benefit of having a generic msg type outweighs this cost. 

All concrete msg types must implement the shallow `Msg` trait.
As convenience, the trait is implemented for `String`.